### PR TITLE
Decode SMF 2.1 cookie as an associative array

### DIFF
--- a/ForumSessionProvider/ForumSessionProvider.php
+++ b/ForumSessionProvider/ForumSessionProvider.php
@@ -263,7 +263,7 @@ class ForumSessionProvider extends ImmutableSessionProviderWithCookie {
             case 'elk1.0':
             case 'elk1.1':
             case 'smf2.1':
-                list($this->userId, $this->password) = json_decode($_COOKIE[$this->cookieName]);
+                list($this->userId, $this->password) = json_decode($_COOKIE[$this->cookieName], true);
                 break;
             case 'smf2.0':
                 list($this->userId, $this->password) = unserialize($_COOKIE[$this->cookieName]);


### PR DESCRIPTION
Otherwise the data doesn't get set in the array properly and page loads crash hard.